### PR TITLE
fix doc link in README

### DIFF
--- a/vue/README.md
+++ b/vue/README.md
@@ -1,6 +1,6 @@
 ## App UI Template
 
-[Vue.js](https://vuejs.org/)-based web app template for your Cosmos SDK blockchain. Use the template to quickly bootstrap your app. To learn more, check out the components in `@starport/vue` and the [Starport documentation](https://docs.starport.network/).
+[Vue.js](https://vuejs.org/)-based web app template for your Cosmos SDK blockchain. Use the template to quickly bootstrap your app. To learn more, check out the components in `@starport/vue` and the [Starport documentation](https://docs.starport.com/).
 
 
 ## Project setup


### PR DESCRIPTION
a little doc link attention

Starport docs are now at https://docs.starport.com/ 