### PR TITLE
Fix error when executing export with --for-zero-height

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -150,7 +150,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	counter := int16(0)
 
 	for ; iter.Valid(); iter.Next() {
-		addr := sdk.ValAddress(iter.Key()[1:])
+		addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))
 		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")


### PR DESCRIPTION
If this is not implement, executing export with --for-zero-height will encounter error: "panic: expected validator, not found"

Credit: https://github.com/cosmos/gaia/pull/1015