### PR TITLE
Revert "updated seed and added peer"

### DIFF
--- a/peers_seeds_and_services.md
+++ b/peers_seeds_and_services.md
@@ -5,16 +5,9 @@ We'd like to ask you to provide us your ***endpoints*** and/or ***persistent_pee
 
 # Persistent_peers
 
-## StakeLab
-5eb75c20a77ccf960df396b187b86d6324b40123@51.68.226.61:26656
-11612d58955e5f073a6e70ce83129d63b8f5c654@65.108.139.109:26666
-
 ## Stakely
 3cdfe02efd4432280707d2949e064a9d8db412b3@178.62.98.158:26656 
 d806bb39349751c142627a547c23c586a787ef26@138.68.78.210:26656
-
-## Blockscope
-ddb620e7c7a6b5a8a53352037cde927681012ab4@65.21.229.209:37656
 
 ## BloClick
 be87c9abf1c54e1cc2f37e68d21fcd61679abb4c@65.21.196.90:46656 
@@ -125,16 +118,6 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
         "provider": "BitCanna"
       },
       {
-        "id": "5eb75c20a77ccf960df396b187b86d6324b40123",
-        "address": "51.68.226.61:26656",
-        "provider": "StakeLab"
-      },
-      {
-        "id": "11612d58955e5f073a6e70ce83129d63b8f5c654",
-        "address": "65.108.139.109:26666",
-        "provider": "StakeLab"
-      },
-      {
         "id": "3cdfe02efd4432280707d2949e064a9d8db412b3",
         "address": "178.62.98.158:26656",
         "provider": "Stakely"
@@ -143,11 +126,6 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
         "id": "d806bb39349751c142627a547c23c586a787ef26",
         "address": "138.68.78.210:26656",
         "provider": "Stakely"
-      },
-      {
-        "id": "ddb620e7c7a6b5a8a53352037cde927681012ab4",
-        "address": "65.21.229.209:37656",
-        "provider": "Blockscope"
       },
       {
         "id": "df99de6cec9152c517990317b340b8b9a307493c",
@@ -198,10 +176,6 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
       {
         "address": "https://lcd.bitcanna.io",
         "provider": "bitcanna"
-      },
-      {
-        "address": "http://bitcanna.stakelab.fr/",
-        "provider": "stakelab"
       },
       {
         "address": "https://bitcanna-api.panthea.eu",

--- a/peers_seeds_and_services.md
+++ b/peers_seeds_and_services.md
@@ -42,8 +42,6 @@ ec12bf44fd3c64db457f45f7d0111735c559a37d@185.218.126.71:26657
 ## STAVR
 0bf629f4e055af47f7c35bb444cb9013d18b9941@141.95.124.151:21326
 
-## Panthea EU
-0a658df9d9fab096983a12e6f878e87281a15ce6@bitcanna-peer.panthea.eu:27656
 
 # Seeds
 ## BitCanna (reseted everyday)
@@ -51,7 +49,7 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
 23671067d0fd40aec523290585c7d8e91034a771@seed2.bitcanna.io:26656
 
 ## Panthea EU
-0a658df9d9fab096983a12e6f878e87281a15ce6@bitcanna-seed.panthea.eu:27656
+0a658df9d9fab096983a12e6f878e87281a15ce6@seed2.panthea.eu:27656
 
 
 # StateSync Servers and instructions:
@@ -118,7 +116,7 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
       },
       {
         "id": "0a658df9d9fab096983a12e6f878e87281a15ce6",
-        "address": "bitcanna-seed.panthea.eu:27656",
+        "address": "seed2.panthea.eu:27656",
         "provider": "Panthea EU"
       }
     ],
@@ -162,11 +160,6 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
         "id": "df99de6cec9152c517990317b340b8b9a307493c",
         "address": "193.34.144.156:26656",
         "provider": "ParanormalBrothers"
-      },
-      {
-        "id": "0a658df9d9fab096983a12e6f878e87281a15ce6",
-        "address": "bitcanna-peer.panthea.eu:27656",
-        "provider": "Panthea EU"
       }
     ]
   },

--- a/peers_seeds_and_services.md
+++ b/peers_seeds_and_services.md
@@ -42,6 +42,8 @@ ec12bf44fd3c64db457f45f7d0111735c559a37d@185.218.126.71:26657
 ## STAVR
 0bf629f4e055af47f7c35bb444cb9013d18b9941@141.95.124.151:21326
 
+## Panthea
+bitcanna-peer.panthea.eu@0a658df9d9fab096983a12e6f878e87281a15ce6:27565
 
 # Seeds
 ## BitCanna (reseted everyday)

--- a/peers_seeds_and_services.md
+++ b/peers_seeds_and_services.md
@@ -42,7 +42,7 @@ ec12bf44fd3c64db457f45f7d0111735c559a37d@185.218.126.71:26657
 ## STAVR
 0bf629f4e055af47f7c35bb444cb9013d18b9941@141.95.124.151:21326
 
-## Panthea
+## Panthea EU
 bitcanna-peer.panthea.eu@0a658df9d9fab096983a12e6f878e87281a15ce6:27565
 
 # Seeds

--- a/peers_seeds_and_services.md
+++ b/peers_seeds_and_services.md
@@ -48,10 +48,6 @@ ec12bf44fd3c64db457f45f7d0111735c559a37d@185.218.126.71:26657
 d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
 23671067d0fd40aec523290585c7d8e91034a771@seed2.bitcanna.io:26656
 
-## Panthea EU
-0a658df9d9fab096983a12e6f878e87281a15ce6@seed2.panthea.eu:27656
-
-
 # StateSync Servers and instructions:
 ## BitCanna oficial:
   * https://github.com/BitCannaGlobal/bcna/blob/main/2.1.statesync.md
@@ -113,11 +109,6 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
         "id": "23671067d0fd40aec523290585c7d8e91034a771",
         "address": "seed2.bitcanna.io: 26656",
         "provider": "bitcanna"
-      },
-      {
-        "id": "0a658df9d9fab096983a12e6f878e87281a15ce6",
-        "address": "seed2.panthea.eu:27656",
-        "provider": "Panthea EU"
       }
     ],
     "persistent_peers": [
@@ -160,6 +151,11 @@ d6aa4c9f3ccecb0cc52109a95962b4618d69dd3f@seed1.bitcanna.io:26656
         "id": "df99de6cec9152c517990317b340b8b9a307493c",
         "address": "193.34.144.156:26656",
         "provider": "ParanormalBrothers"
+      },
+      {
+        "id": "0a658df9d9fab096983a12e6f878e87281a15ce6",
+        "address": "bitcanna-peer.panthea.eu:27656",
+        "provider": "Panthea EU"
       }
     ]
   },


### PR DESCRIPTION
Reverts BitCannaGlobal/bcna#89

The same peer can't be `peer` and `seed` at the same time . 
