### PR TITLE
refactor: remove pkg/openapiconsole import

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -107,8 +106,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
-
-	"github.com/ignite/cli/ignite/pkg/openapiconsole"
 
 	appparams "github.com/BitCannaGlobal/bcna/app/params"
 	"github.com/BitCannaGlobal/bcna/docs"
@@ -853,8 +850,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 	ModuleBasics.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// register app's OpenAPI routes.
-	apiSvr.Router.Handle("/static/openapi.yml", http.FileServer(http.FS(docs.Docs)))
-	apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/openapi.yml"))
+	docs.RegisterOpenAPIService(Name, apiSvr.Router)
 }
 
 // RegisterTxService implements the Application.RegisterTxService method.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1,6 +1,40 @@
 package docs
 
-import "embed"
+import (
+	"embed"
+	httptemplate "html/template"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	apiFile   = "/static/openapi.yml"
+	indexFile = "template/index.tpl"
+)
 
 //go:embed static
-var Docs embed.FS
+var Static embed.FS
+
+//go:embed template
+var template embed.FS
+
+func RegisterOpenAPIService(appName string, rtr *mux.Router) {
+	rtr.Handle(apiFile, http.FileServer(http.FS(Static)))
+	rtr.HandleFunc("/", handler(appName))
+}
+
+// handler returns an http handler that servers OpenAPI console for an OpenAPI spec at specURL.
+func handler(title string) http.HandlerFunc {
+	t, _ := httptemplate.ParseFS(template, indexFile)
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.Execute(w, struct {
+			Title string
+			URL   string
+		}{
+			title,
+			apiFile,
+		})
+	}
+}

--- a/docs/template/index.tpl
+++ b/docs/template/index.tpl
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>{{ .Title }}</title>
+        <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui.css" />
+        <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist@3.40.0/favicon-16x16.png" />
+    </head>
+    <body>
+      <h5>Welcome to BitCanna LCD</h5>
+        <div id="swagger-ui"></div>
+
+        <script src="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui-bundle.js"></script>
+        <script>
+            // init Swagger for faucet's openapi.yml.
+            window.onload = function() {
+              window.ui = SwaggerUIBundle({
+                url: {{ .URL }},
+                dom_id: "#swagger-ui",
+                deepLinking: true,
+                layout: "BaseLayout",
+              });
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Remove pkg/openapiconsole import from Ignite:
- adding logic to `/docs/docs.go`
- adding template for HTML container at `/docs/template/`
- removing Ignite import at `go.mod`
- removing call to Ignite import at `app.go`