### PR TITLE
Update 5.cosmovisor.md

### DIFF
--- a/5.cosmovisor.md
+++ b/5.cosmovisor.md
@@ -52,6 +52,7 @@ export DAEMON_HOME=${HOME}/.bcna
 export DAEMON_RESTART_DELAY=30s
 export UNSAFE_SKIP_BACKUP=true
 export DAEMON_LOG_BUFFER_SIZE=512
+export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 
 #add this to continue to use bcnad for commands, this is optional
 PATH="${HOME}/.bcna/cosmovisor/current/bin:$PATH" 
@@ -119,6 +120,7 @@ Environment=DAEMON_HOME=${HOME}/.bcna
 Environment=UNSAFE_SKIP_BACKUP=true
 Environment=DAEMON_RESTART_DELAY=30s
 Environment=DAEMON_LOG_BUFFER_SIZE=512
+Environment=DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 #Optional export DAEMON_DATA_BACKUP_DIR=${HOME}/your_chain_backup_folder
 ExecStart=$(which cosmovisor) run start
 Restart=always


### PR DESCRIPTION
Enforce security setting DAEMON_ALLOW_DOWNLOAD_BINARIES=false (that is not really necessary because by default is disabled)

Attending the [official doc at Cosmos-SDK Github](https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor)
`DAEMON_ALLOW_DOWNLOAD_BINARIES (optional), if set to true, will enable auto-downloading of new binaries (for security reasons, this is intended for full nodes rather than validators). By default, cosmovisor will not auto-download new binaries.`
