### PR TITLE
Check for a length limit in custom modules's fields

### DIFF
--- a/x/bcna/keeper/msg_server_bitcannaid.go
+++ b/x/bcna/keeper/msg_server_bitcannaid.go
@@ -10,7 +10,17 @@ import (
 func (k msgServer) CreateBitcannaid(goCtx context.Context, msg *types.MsgCreateBitcannaid) (*types.MsgCreateBitcannaidResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// Check if a BitCannaID with the same Bcnaid already exists
+	// Checks if field Bcnaid exceeds 256 chars.
+	if len(msg.Bcnaid) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Bcnaid exceeds the limit of 256 characters")
+	}
+
+	// Checks if field Address exceeds 256 chars.
+	if len(msg.Address) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Address exceeds the limit of 256 characters")
+	}
+
+	// Checks if a BitCannaID with the same Bcnaid already exists
 	if k.HasBitcannaidWithBcnaid(ctx, msg.Bcnaid) {
 		return nil, types.ErrDuplicateBitcannaid.Wrapf("BitCannaID with Bcnaid %s already exists", msg.Bcnaid)
 	}
@@ -32,6 +42,16 @@ func (k msgServer) CreateBitcannaid(goCtx context.Context, msg *types.MsgCreateB
 
 func (k msgServer) UpdateBitcannaid(goCtx context.Context, msg *types.MsgUpdateBitcannaid) (*types.MsgUpdateBitcannaidResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// Checks if field Bcnaid exceeds 256 chars.
+	if len(msg.Bcnaid) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Bcnaid exceeds the limit of 256 characters")
+	}
+
+	// Checks if field Address exceeds 256 chars.
+	if len(msg.Address) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Address exceeds the limit of 256 characters")
+	}
 
 	// Check if a BitCannaID with the same Bcnaid already exists
 	if k.HasBitcannaidWithBcnaid(ctx, msg.Bcnaid) {

--- a/x/bcna/keeper/msg_server_supplychain.go
+++ b/x/bcna/keeper/msg_server_supplychain.go
@@ -10,6 +10,23 @@ import (
 func (k msgServer) CreateSupplychain(goCtx context.Context, msg *types.MsgCreateSupplychain) (*types.MsgCreateSupplychainResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	// Checks if field Product exceeds 256 chars.
+	if len(msg.Product) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Product exceeds the limit of 256 characters")
+	}
+	// Checks if field Info exceeds 256 chars.
+	if len(msg.Info) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Info exceeds the limit of 256 characters")
+	}
+	// Checks if field Supplyinfo exceeds 256 chars.
+	if len(msg.Supplyinfo) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Supplyinfo exceeds the limit of 256 characters")
+	}
+	// Checks if field Supplyextra exceeds 256 chars.
+	if len(msg.Supplyextra) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Supplyextra exceeds the limit of 256 characters")
+	}
+
 	var supplychain = types.Supplychain{
 		Creator:     msg.Creator,
 		Product:     msg.Product,
@@ -30,6 +47,23 @@ func (k msgServer) CreateSupplychain(goCtx context.Context, msg *types.MsgCreate
 
 func (k msgServer) UpdateSupplychain(goCtx context.Context, msg *types.MsgUpdateSupplychain) (*types.MsgUpdateSupplychainResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// Checks if field Product exceeds 256 chars.
+	if len(msg.Product) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Product exceeds the limit of 256 characters")
+	}
+	// Checks if field Info exceeds 256 chars.
+	if len(msg.Info) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Info exceeds the limit of 256 characters")
+	}
+	// Checks if field Supplyinfo exceeds 256 chars.
+	if len(msg.Supplyinfo) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Supplyinfo exceeds the limit of 256 characters")
+	}
+	// Checks if field Supplyextra exceeds 256 chars.
+	if len(msg.Supplyextra) > 256 {
+		return nil, types.ErrMaxCharacters.Wrapf("Supplyextra exceeds the limit of 256 characters")
+	}
 
 	var supplychain = types.Supplychain{
 		Creator:     msg.Creator,

--- a/x/bcna/types/errors.go
+++ b/x/bcna/types/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrUnauthorized        = sdkioerrors.Register(ModuleName, 1103, "Incorrect owner")
 	ErrUnrecognized        = sdkioerrors.Register(ModuleName, 1104, "Unrecognized messager")
 	ErrInvalidAddress      = sdkioerrors.Register(ModuleName, 1105, "invalid address")
+	ErrMaxCharacters       = sdkioerrors.Register(ModuleName, 1106, "input exceeds the permitted length limit")
 )


### PR DESCRIPTION
Length validation has been added to:
* the `Bcnaid` and `Address` fields of MsgCreateBitcannaid & MsgUpdateBitcannaid
* the `Product` , `Info`, `Supplyinfo` & `Supplyextra` of MsgCreateSupplychain & MsgUpdateSupplychain